### PR TITLE
Allow reading from and writing to empty slices

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,7 +367,7 @@ impl<Ctx> BytesExt<Ctx> for [u8] {
     {
         let slice = self;
 
-        if *offset >= slice.len() {
+        if *offset > slice.len() {
             return Err(Error::BadOffset(*offset));
         };
 
@@ -400,7 +400,7 @@ impl<Ctx> BytesExt<Ctx> for [u8] {
     {
         let slice = self;
 
-        if *offset >= slice.len() {
+        if *offset > slice.len() {
             return Err(Error::BadOffset(*offset));
         };
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -327,3 +327,45 @@ fn test_api() {
     write.write_with(&mut 0, header, BE).unwrap();
     assert_eq!(write, bytes);
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Empty;
+
+impl<'a> TryRead<'a, ()> for Empty {
+    fn try_read(bytes: &'a [u8], _ctx: ()) -> Result<(Self, usize)> {
+        Ok((Self, 0))
+    }
+}
+
+impl TryWrite<()> for Empty {
+    fn try_write(self, bytes: &mut [u8], _ctx: ()) -> Result<usize> {
+        Ok(0)
+    }
+}
+
+#[test]
+fn test_empty() {
+    let empty_bytes: [u8; 0] = [];
+    let mut offset = 0;
+    let empty: Empty = empty_bytes.read(&mut offset).unwrap();
+    assert_eq!(empty, Empty);
+    assert_eq!(offset, 0);
+
+    let zero_bytes = [0; 8];
+    let mut offset = 0;
+    let empty: Empty = zero_bytes.read(&mut offset).unwrap();
+    assert_eq!(empty, Empty);
+    assert_eq!(offset, 0);
+
+    let mut write_empty_bytes: [u8; 0] = [];
+    let mut offset = 0;
+    write_empty_bytes.write(&mut offset, Empty).unwrap();
+    assert_eq!(write_empty_bytes, empty_bytes);
+    assert_eq!(offset, 0);
+
+    let mut write_zero_bytes = [0u8; 4];
+    let mut offset = 0;
+    write_zero_bytes.write(&mut offset, Empty).unwrap();
+    assert_eq!(write_zero_bytes, [0u8; 4]);
+    assert_eq!(offset, 0);
+}


### PR DESCRIPTION
This is a small PR that tweaks `BytesExt::read_with()` and `BytesExt::write_with()` to avoid returning a `BadOffset` error when reading from or writing to an empty slice. Of course, the type being read or written must not try to actually read or write any bytes, since that would be out of bounds... so this PR really only affects zero-sized types. Here's a simple example:

```rust
use byte::{BytesExt, Result, TryRead, TryWrite};

#[derive(Debug, Clone, PartialEq, Eq)]
struct Empty;

impl<'a> TryRead<'a, ()> for Empty {
    fn try_read(bytes: &'a [u8], _ctx: ()) -> Result<(Self, usize)> {
        Ok((Self, 0))
    }
}

impl TryWrite<()> for Empty {
    fn try_write(self, bytes: &mut [u8], _ctx: ()) -> Result<usize> {
        Ok(0)
    }
}

fn main() {
    let mut bytes = [0u8; 4];
    let mut offset = 0;
    let Empty = bytes.read(&mut offset).unwrap();
    let n: u32 = bytes.read(&mut offset).unwrap();
    let Empty = bytes.read(&mut offset).unwrap();

    let mut bytes = [0u8; 4];
    let mut offset = 0;
    bytes.write(&mut offset, Empty).unwrap();
    bytes.write(&mut offset, 4u32).unwrap();
    bytes.write(&mut offset, Empty).unwrap();
}
```

I ran into this use-case when writing code targeting bare metal on a Raspberry Pi. The [mailbox property interface](https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface) from the Pi's VideoCore has several requests and responses that have a length of zero. With the abstractions I've started to write out, it'd be super nice if I could call `.read()` or `.write()` even when targeting these zero-sized request/response types!

I think this can be worked around today by calling `TryRead::try_read()` / `TryWrite::try_write()` directly, but in my opinion this PR would be a more intuitive solution.